### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -1475,6 +1475,23 @@ async function initTopProjects() {
 	}
 }
 
+function sanitizeNavigationUrl(candidate, fallback = 'https://www.youtube.com/') {
+	try {
+		const parsed = new URL(candidate, 'https://www.youtube.com');
+		if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+			return parsed.href;
+		}
+	} catch (error) {
+		// Ignore parse errors and fall through to fallback.
+	}
+	try {
+		const safeFallback = new URL(fallback, 'https://www.youtube.com');
+		return safeFallback.href;
+	} catch (error) {
+		return 'https://www.youtube.com/';
+	}
+}
+
 async function initLatestUploadCard() {
 	const card = document.querySelector('[data-latest-video]');
 	if (!card) {
@@ -1685,7 +1702,7 @@ async function initLatestUploadCard() {
 			}
 		}
 		if (linkEl) {
-			linkEl.href = resolvedLink;
+			linkEl.href = sanitizeNavigationUrl(resolvedLink, channelUrl);
 		}
 
 		const derivedVideoId = videoId || extractVideoId(resolvedLink);


### PR DESCRIPTION
Potential fix for [https://github.com/COOLmanYT/mycoolwebsite/security/code-scanning/5](https://github.com/COOLmanYT/mycoolwebsite/security/code-scanning/5)

To fix this safely without changing intended functionality, validate and canonicalize the final link before assigning it to `linkEl.href`, and fall back to a trusted safe URL (the computed channel URL, or YouTube root) when invalid. The best approach is:

1. Add a small helper in `script.js` that:
   - parses a candidate URL with `new URL(..., 'https://www.youtube.com')`,
   - allows only `http:` and `https:` protocols,
   - returns a safe fallback if parsing fails or protocol is disallowed.

2. Replace the direct assignment `linkEl.href = resolvedLink;` with assignment to the sanitized URL from the helper.

This addresses both variants (taint from `data-channel-id` and `data-channel-user`) since both flows converge into `resolvedLink`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
